### PR TITLE
[YH-15]タスク追加機能

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,15 +19,15 @@ export const App = () => {
 
   // TodoFormの入力値をsetTodoItems()にセット
   const handleTodoAdd = (todoText, todoLimit) => {
-    setTodoItems([
-      ...todoItems,
+    setTodoItems((prev) => [
+      ...prev,
       {
         id: getKey(),
         todoText: todoText,
         todoLimit: todoLimit,
         todoStatus: NOT_START,
       }
-    ]);
+    ])
   };
   
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import './css/App.css';
-import { useId } from "react";
+import { useState } from "react";
 import { RadioForm } from './components/RadioForm';
 import { TodoForm } from './components/TodoForm';
 import { TodoList } from "./components/TodoList";
@@ -11,37 +11,35 @@ export const App = () => {
   const DONE = "完了";
   const TODO_STATUS = [NOT_START, DONE];
 
-  const todos = [
-    {
-      id: useId(),
-      todoName: 'AAA',
-      todoLimit: '2023-08-22',
-      todoStatus: NOT_START,
-    },
-    {
-      id: useId(),
-      todoName: 'BBB',
-      todoLimit: '2023-08-22',
-      todoStatus: NOT_START,
-    },
-    {
-      id: useId(),
-      todoName: 'CCC',
-      todoLimit: '2023-08-22',
-      todoStatus: NOT_START,
-    },
-  ];
+  // ランダムのIDを生成
+  const getKey = () => Math.random().toString(32).substring(2, 5);
+
+  // タスク情報のState
+  const [todoItems, setTodoItems] = useState([]);
+
+  // TodoFormの入力値をsetTodoItems()にセット
+  const handleTodoAdd = (todoText, todoLimit) => {
+    setTodoItems([
+      ...todoItems,
+      {
+        id: getKey(),
+        todoText: todoText,
+        todoLimit: todoLimit,
+        todoStatus: NOT_START,
+      }
+    ]);
+  };
   
   return (
     <>
       <div className="container">
         <h1 className="title">JS Todoリスト</h1>
   
-        <TodoForm />
+        <TodoForm handleTodoAdd={handleTodoAdd} />
   
         <RadioForm />
   
-        <TodoList todos={todos} />
+        <TodoList todoItems={todoItems} />
       </div>
     </>
   );

--- a/src/components/TodoForm.jsx
+++ b/src/components/TodoForm.jsx
@@ -1,14 +1,75 @@
-export const TodoForm = () => {
+import { useState } from "react";
+
+export const TodoForm = ({handleTodoAdd}) => {
+
+  const [todoText, setTodoText] = useState(''); // タスク名のState
+  const [todoLimit, setTodoLimit] = useState(''); // 期日のState
+
+  // タスク追加用の関数
+  const addTodo = () => {
+    if(todoText === '') {
+      alert('タスク名を追加してください');
+      return;
+    }
+    handleTodoAdd(todoText, todoLimit);
+    setTodoText('');
+    setTodoLimit('');
+  };
+
+  // todoTextの入力値をsetTodoText()にセット
+  const handleTodoTextChange = (e) => {
+    setTodoText(e.target.value);
+  };
+
+  // todoLimitの入力値をsetTodoLimit()にセット
+  const handleTodoLimitChange = (e) => {
+    setTodoLimit(e.target.value);
+  };
+
+  // ⌘ + Enterでタスクを追加
+  const handleKeyDown = (keyEvent) => {
+    if(keyEvent.key === 'Enter') {
+      keyEvent.preventDefault();
+    }
+
+    if(keyEvent.key === 'Enter' && (keyEvent.ctrlKey || keyEvent.metaKey)) {
+      addTodo();
+    }
+  };
+
+  // 追加ボタンでタスクを追加
+  const handleSubmit = (submitEvent) => {
+    submitEvent.preventDefault();
+    addTodo();
+  };
+
   return (
     <>
-      <form id="todoForm" className="input">
+      <form id="todoForm" className="input" onSubmit={handleSubmit}>
         <dl className="input__block input__name">
-          <dt className="input__label"><label htmlFor="todoName">タスク名</label></dt>
-          <dd className="input__field"><input id="todoName" type="text" name="todoName" /></dd>
+          <dt className="input__label"><label htmlFor="todoText">タスク名</label></dt>
+          <dd className="input__field">
+            <input
+              id="todoText"
+              type="text"
+              name="todoText"
+              value={todoText}
+              onChange={handleTodoTextChange}
+              onKeyDown={handleKeyDown}
+            />
+          </dd>
         </dl>
         <dl className="input__block input__date">
           <dt className="input__label"><label htmlFor="todoLimit">期日</label></dt>
-          <dd className="input__field"><input id="todoLimit" type="date" name="todoLimit" /></dd>
+          <dd className="input__field">
+            <input
+              id="todoLimit"
+              type="date"
+              name="todoLimit"
+              value={todoLimit}
+              onChange={handleTodoLimitChange}
+            />
+          </dd>
         </dl>
         <div className="input__btn">
           <button id="addBtn" className="btn btn--add">追加</button>

--- a/src/components/TodoItem.jsx
+++ b/src/components/TodoItem.jsx
@@ -1,9 +1,9 @@
-export const TodoItem = ({id, todoName, todoLimit, todoStatus}) => {
+export const TodoItem = ({id, todoText, todoLimit, todoStatus}) => {
   return (
     <>
       <tr>
         <td>{id}</td>
-        <td>{todoName}</td>
+        <td>{todoText}</td>
         <td>
           <button className="btn btn--notStart">{todoStatus}</button>
         </td>

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -16,8 +16,8 @@ export const TodoList = (props) => {
             </tr>
           </thead>
           <tbody id="addTodoTarget">
-            {props.todos.map((todo) => {
-              return <TodoItem key={todo.id} {...todo} />
+            {props.todoItems.map((item) => {
+              return <TodoItem key={item.id} {...item} />
             })}
           </tbody>
         </table>


### PR DESCRIPTION
## 目的

<!-- タスクの目的を出来るだけわかりやすく詳細に書く -->

useStateでデータを管理できるようにする

## 実施内容

<!-- 具体的に何をするのかを出来るだけ分かりやすく詳細に書く -->

- [x]  タスク名のステート、期日のステートを追加
- [x]  タスク名が空だったらアラートを表示
- [x]  タスクは「追加ボタンをクリック」or「⌘ + Enter」で追加できる
- [x]  タスクを追加したら一覧に表示される

## Screenshots

<!-- スクリーンショットを添付する -->

[]()

[]()

## テスト

<!-- 動作確認方法やテスト手順を出来るだけ詳細に書く -->

- [x]  タスク名が未入力の場合、「追加ボタンをクリック」or「⌘ + Enter」でアラートが出る
- [x]  タスク名と期日を追加
    - [x]  追加ボタンをクリックしたら、一覧にタスク（タスク名と期日）が追加される
    - [x]  ⌘ + Enterを押したら、一覧にタスク（タスク名と期日）が追加される
    - [x]  Enterを押した場合、一覧にタスクは追加されない
    - [x]  タスクが追加された際、状態は「作業前」になっている
    - [x]  タスクが追加された際、「タスク名」「期日」がリセットされる

## 確認事項

<!-- 問題点は可能な限り対応して難しい場合は補足に記載する -->

- [ ]  動作確認をしたか？
- [ ]  新たにエラーは発生していないか？
- [ ]  merge後に新たなTaskやIssueは発生するか？（発生する場合はTaskを作成したか？）

## 補足

<!-- 補足すべきことがあれば書く -->