### PR TITLE
[YH-18]表示切り替え機能

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,10 +12,11 @@ export const TodoDeleteContext = createContext();
 
 export const App = () => {
 
+  // タスク状態の定数
   const ALL = "全て";
   const NOT_START = "作業前";
   const DONE = "完了";
-  const TODO_STATUS = [NOT_START, DONE];
+  const TODO_STATUS = [ALL, NOT_START, DONE];
 
   // ランダムのIDを生成
   const getKey = () => Math.random().toString(32).substring(2, 5);
@@ -58,9 +59,6 @@ export const App = () => {
   // 状態ラジオボタン 選択されたオプションを管理するState
   const [selectedStatus, setSelectedStatus] = useState(ALL);
 
-  // 状態ラジオボタン オプション
-  const RADIO_STATUS = [ALL, NOT_START, DONE];
-
   // 状態ラジオボタン オプションを取得
   const handleRadioStatusChange = (radioEvent) => {
     setSelectedStatus(radioEvent.target.value);
@@ -85,7 +83,7 @@ export const App = () => {
   
         <TodoForm handleTodoAdd={handleTodoAdd} />
   
-        <RadioForm radioStatus={RADIO_STATUS} selectedStatus={selectedStatus} onChange={handleRadioStatusChange} />
+        <RadioForm radioStatus={TODO_STATUS} selectedStatus={selectedStatus} handleRadioStatusChange={handleRadioStatusChange} />
 
         <TodoContext.Provider value={handleTodoChangeStatus}>
           <TodoDeleteContext.Provider value={handleTodoDelete}>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,29 @@ export const App = () => {
       }
     ])
   };
+
+  // 状態ラジオボタン 選択されたオプションを管理するState
+  const [selectedStatus, setSelectedStatus] = useState(ALL);
+
+  // 状態ラジオボタン オプション
+  const RADIO_STATUS = [ALL, NOT_START, DONE];
+
+  // 状態ラジオボタン オプションを取得
+  const handleRadioStatusChange = (radioEvent) => {
+    setSelectedStatus(radioEvent.target.value);
+  }
+
+  // TODOリスト フィルタリング
+  const filteredTodos = todoItems.filter((todoItem) => {
+    switch(selectedStatus) {
+      case NOT_START:
+        return todoItem.todoStatus === NOT_START;
+      case DONE:
+        return todoItem.todoStatus === DONE;
+      default:
+        return todoItem;
+    }
+  });
   
   return (
     <>
@@ -37,9 +60,9 @@ export const App = () => {
   
         <TodoForm handleTodoAdd={handleTodoAdd} />
   
-        <RadioForm />
-  
-        <TodoList todoItems={todoItems} />
+        <RadioForm radioStatus={RADIO_STATUS} selectedStatus={selectedStatus} onChange={handleRadioStatusChange} />
+
+        <TodoList todoItems={filteredTodos} />
       </div>
     </>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -87,11 +87,9 @@ export const App = () => {
   
         <RadioForm radioStatus={RADIO_STATUS} selectedStatus={selectedStatus} onChange={handleRadioStatusChange} />
 
-        <TodoList todoItems={filteredTodos} />
-
         <TodoContext.Provider value={handleTodoChangeStatus}>
           <TodoDeleteContext.Provider value={handleTodoDelete}>
-            <TodoList todoItems={todoItems} />
+            <TodoList todoItems={filteredTodos} />
           </TodoDeleteContext.Provider>
         </TodoContext.Provider>
       </div>

--- a/src/components/RadioForm.jsx
+++ b/src/components/RadioForm.jsx
@@ -1,4 +1,4 @@
-export const RadioForm = ({radioStatus, selectedStatus, onChange}) => {
+export const RadioForm = ({radioStatus, selectedStatus, handleRadioStatusChange}) => {
   return (
     <>
       <form action="" id="radioForm">
@@ -9,12 +9,11 @@ export const RadioForm = ({radioStatus, selectedStatus, onChange}) => {
                 <li key={status} className="state__item">
                   <label>
                     <input
-                      id={`state-${status}`}
                       type="radio"
                       name="state"
                       value={status}
                       checked={selectedStatus === status}
-                      onChange={onChange}
+                      onChange={handleRadioStatusChange}
                     />
                     <span>{status}</span>
                   </label>

--- a/src/components/RadioForm.jsx
+++ b/src/components/RadioForm.jsx
@@ -1,26 +1,27 @@
-export const RadioForm = () => {
+export const RadioForm = ({radioStatus, selectedStatus, onChange}) => {
   return (
     <>
       <form action="" id="radioForm">
         <ul id="stateRadio" className="state">
-          <li className="state__item">
-            <label>
-              <input id="state-all" type="radio" name="state" value="全て" defaultChecked={true} />
-              <span>全て</span>
-            </label>
-          </li>
-          <li className="state__item">
-            <label>
-              <input id="state-pending" type="radio" name="state" value="作業前" />
-              <span>作業前</span>
-            </label>
-          </li>
-          <li className="state__item">
-            <label>
-              <input id="state-done" type="radio" name="state" value="完了" />
-              <span>完了</span>
-            </label>
-          </li>
+          {
+            radioStatus.map((status) => {
+              return (
+                <li key={status} className="state__item">
+                  <label>
+                    <input
+                      id={`state-${status}`}
+                      type="radio"
+                      name="state"
+                      value={status}
+                      checked={selectedStatus === status}
+                      onChange={onChange}
+                    />
+                    <span>{status}</span>
+                  </label>
+                </li>
+              )
+            })
+          }
         </ul>
       </form>
     </>


### PR DESCRIPTION
## 目的

- 状態のラジオボタンに応じて、該当する状態のタスクが一覧で表示される

## 実施内容

- [x]  状態ラジオボタン 選択されたオプションを管理するStateを追加
- [x]  状態を指定した定数をmap関数を使用してラジオボタンを表示
- [x]  状態ラジオボタン オプションを取得する関数を追加
- [x]  フィルタリングの関数を追加

## テスト

<!-- 動作確認方法やテスト手順を出来るだけ詳細に書く -->

- [x]  任意の状態のタスクが一覧に表示されるかどうかをテスト
    - [x]  タスクを3項目ほど新規追加し、状態を「作業中」「完了」をそれぞれ選択しておく
    - [x]  ラジオボタン「作業中」を選択したら、タスク一覧に「作業中」のタスクが表示される
    - [x]  ラジオボタン「完了」を選択したら、タスク一覧に「完了」のタスクが表示される
    - [x]  ラジオボタン「全て」を選択したら、タスク一覧に全てのタスクが表示される
    - [x]  状態の「作業中」「完了」を変更した際、異なる状態のタスクが一覧から消え、該当する一覧に表示される

## 確認事項

<!-- 問題点は可能な限り対応して難しい場合は補足に記載する -->

- [x]  動作確認をしたか？
- [x]  新たにエラーは発生していないか？
- [x]  merge後に新たなTaskやIssueは発生するか？（発生する場合はTaskを作成したか？）